### PR TITLE
Filters Vimeo URLs proceeded by <div> or <br> tags

### DIFF
--- a/lib/html/pipeline/vimeo/vimeo_filter.rb
+++ b/lib/html/pipeline/vimeo/vimeo_filter.rb
@@ -16,9 +16,10 @@ module HTML
     # This filter does not write additional information to the context.
     class VimeoFilter < TextFilter
       def call
-        regex = /(\s|^)https?:\/\/(www.)?vimeo\.com\/([A-Za-z0-9._%-]*)((\?|#)\S+)?/
+        regex = /(\s|^|<div>|<br>)https?:\/\/(www.)?vimeo\.com\/([A-Za-z0-9._%-]*)((\?|#)\S+)?/
         @text.gsub(regex) do
           vimeo_id = $3
+          close_tag = $1 if ["<div>", "<br>"].include? $1
           width  = context[:vimeo_width] || 440
           height = context[:vimeo_height] || 248
           show_title      = "title=0"    unless context[:vimeo_show_title]
@@ -29,7 +30,7 @@ module HTML
           query_string_variables = [show_title, show_byline, show_portrait].compact.join("&")
           query_string    = "?" + query_string_variables unless query_string_variables.empty?
 
-          %{<iframe src="//player.vimeo.com/video/#{vimeo_id}#{query_string}" width="#{width}" height="#{height}" frameborder="#{frameborder}"#{allow_fullscreen}></iframe>}
+          %{#{close_tag}<iframe src="//player.vimeo.com/video/#{vimeo_id}#{query_string}" width="#{width}" height="#{height}" frameborder="#{frameborder}"#{allow_fullscreen}></iframe>}
         end
       end
     end

--- a/spec/html/pipeline/vimeo_filter_spec.rb
+++ b/spec/html/pipeline/vimeo_filter_spec.rb
@@ -18,4 +18,16 @@ describe HTML::Pipeline::VimeoFilter do
   it "doens't transform HTML link" do
     expect(described_class.to_html(html_with_vimeo_url)).to eq(html_with_vimeo_url)
   end
+
+  it "does transform link wrapped in a <div>" do
+    expect(described_class.to_html("<div>#{vimeo_url}</div>")).to eq(
+      %(<div><iframe src="//player.vimeo.com/video/137266757?title=0&byline=0&portrait=0" width="440" height="248" frameborder="0"></iframe></div>)
+    )
+  end
+
+  it "does transform link after <br>" do
+    expect(described_class.to_html("<br>#{vimeo_url}")).to eq(
+      %(<br><iframe src="//player.vimeo.com/video/137266757?title=0&byline=0&portrait=0" width="440" height="248" frameborder="0"></iframe>)
+    )
+  end
 end


### PR DESCRIPTION
I have a body of text that will often contain `<br><br>#{video_tag}` which isn't being caught by this filter. I looked to [html-pipeline-youtube](https://github.com/st0012/html-pipeline-youtube) to see what they were doing and noticed they're also catching `<div>` tags, which I imagine would be useful as well.

Thanks!
-Wendy
